### PR TITLE
[5913274][REF] base_c : cost_from_supplierinfo dependency is useless

### DIFF
--- a/base_c/__manifest__.py
+++ b/base_c/__manifest__.py
@@ -4,10 +4,9 @@
     "category": "Misc",
     "author": "Akretion",
     "license": "AGPL-3",
-    "version": "18.0.1.0.3",
+    "version": "18.0.1.1.0",
     "depends": [
         "contacts",
-        "cost_from_supplierinfo",
         "l10n_fr",  # better to primarly load this instead of 'account'
         "maintenance",
         "product_second_category",


### PR DESCRIPTION
### Description

Link to task: [#5913274](https://www.odoo.com/web#model=project.task&id=5913274)

### All Submissions:

* [ ] My commit respects the [Odoo commit guideline](https://www.odoo.com/documentation/15.0/developer/misc/other/guidelines.html#git)
* [ ] My commit message respects the [commit template](https://github.com/odoo-ps/psbe-process/wiki/Commits-message-guidelines#template)
* [ ] I have used pre-commit
* [ ] The PR contains **only** my modification and **no other external** commit

### Sh/Runbot:

* [ ] The commits pass test and the branch is green
* [ ] Unit tests have been implemented / standard ones rewritten
* [ ] The Staging is ISO-Prod and will contain only this dev

### Upgrade:

* [ ] The data affected (*if any*) by the changes has been migrated 

### Maintenance reminders:

* Always bump the version of the manifest on the affected modules.
* Notify the developer responsible for the initial development task (when this is relevant).
